### PR TITLE
Fix: #4 Fails when using old versions of clang-tidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@
 - Initial release
 
 ## [Unreleased]
+
+- Fixed: Fails with "Cannot set property 'Severity' of undefined" when using
+old versions of clang-tidy


### PR DESCRIPTION
The format of clang-tidy "--export-fixes=-" changed at some point.
This caused the error "Cannot set property 'Severity' of undefined"
when running old versions of clang-tidy.

See issue #4 for more details.