### PR TITLE
Support straight C in addition to C++

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     ],
     "activationEvents": [
         "onLanguage:cpp",
+        "onLanguage:c",
         "onCommand:clang-tidy.lintFile",
         "workspaceContains:**/.clang-tidy"
     ],

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -13,7 +13,7 @@ export async function lintActiveTextDocument(loggingChannel: vscode.OutputChanne
 }
 
 export async function lintTextDocument(file: vscode.TextDocument, loggingChannel: vscode.OutputChannel) {
-    if (!['cpp'].includes(file.languageId)) {
+    if (!['cpp','c'].includes(file.languageId)) {
         return [];
     }
     if (file.uri.scheme !== 'file') {


### PR DESCRIPTION
Hi, I'd love it if this VSCode extension supported regular C as well.  This seems to work for me.