### PR TITLE
Add fix on save capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
                     "default": true,
                     "description": "Automatically lint files when they are saved"
                 },
+                "clang-tidy.fixOnSave": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Automatically fix resolvable errors detected by clang-tidy in files when they are saved"
+                },
                 "clang-tidy.buildPath": {
                     "type": "string",
                     "default": "",

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -8,11 +8,11 @@ export async function lintActiveTextDocument(loggingChannel: vscode.OutputChanne
 
     return {
         document: vscode.window.activeTextEditor.document,
-        diagnostics: await lintTextDocument(vscode.window.activeTextEditor.document, loggingChannel)
+        diagnostics: await lintTextDocument(vscode.window.activeTextEditor.document, loggingChannel, false)
     };
 }
 
-export async function lintTextDocument(file: vscode.TextDocument, loggingChannel: vscode.OutputChannel) {
+export async function lintTextDocument(file: vscode.TextDocument, loggingChannel: vscode.OutputChannel, fixErrors: boolean) {
     if (!['cpp'].includes(file.languageId)) {
         return [];
     }
@@ -26,6 +26,6 @@ export async function lintTextDocument(file: vscode.TextDocument, loggingChannel
         return [];
     }
 
-    const clangTidyOut = await runClangTidy([file.uri.fsPath], workspaceFolder.uri.fsPath, loggingChannel);
+    const clangTidyOut = await runClangTidy([file.uri.fsPath], workspaceFolder.uri.fsPath, loggingChannel, fixErrors);
     return collectDiagnostics(clangTidyOut, file);
 }

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -2,7 +2,7 @@ import { ChildProcess, execFile, execFileSync } from 'child_process';
 import * as vscode from 'vscode';
 import * as jsYaml from 'js-yaml';
 
-function clangTidyArgs(files: string[]) {
+function clangTidyArgs(files: string[], fixErrors: boolean) {
     let args: string[] = [...files, '--export-fixes=-'];
 
     const checks = vscode.workspace
@@ -35,6 +35,10 @@ function clangTidyArgs(files: string[]) {
 
     if (buildPath.length > 0) {
         args.push(`-p="${buildPath}"`);
+    }
+
+    if (fixErrors) {
+        args.push('--fix');
     }
 
     return args;
@@ -79,12 +83,12 @@ export function killClangTidy() {
     }
 }
 
-export function runClangTidy(files: string[], workingDirectory: string, loggingChannel: vscode.OutputChannel): Promise<string> {
+export function runClangTidy(files: string[], workingDirectory: string, loggingChannel: vscode.OutputChannel, fixErrors: boolean): Promise<string> {
     killClangTidy();
 
     return new Promise(resolve => {
         const clangTidy = clangTidyExecutable();
-        const args = clangTidyArgs(files);
+        const args = clangTidyArgs(files, fixErrors);
 
         loggingChannel.appendLine(`> ${clangTidy} ${args.join(' ')}`);
         loggingChannel.appendLine(`Working Directory: ${workingDirectory}`);


### PR DESCRIPTION
This references #9.

I went for the Fix On Save option here rather than the Quick Fixes one, tell me what you think in terms of UX. I am personally more in favor of Fix On Save (it's notably used by the ESLint extension, so I think a lot of VSCode users are used to it), but this is debatable.

I do have 2 concerns though :
- There is a noticeable delay between the moment the file is saved and the moment the fixes are applied, even for small files : I am not sure if we can do something to make it happen quicker, or if this delay comes from clang-tidy itself, but it is troubling as an user. Maybe a status bar `withProgress` or a notification indicating "Fixing files..." could help.

- I am not fond of passing a boolean `fixErrors` flag down the function call chain like I did, but didn't really find something better that didn't involve refactoring too much stuff.

What do you think ?