### PR TITLE
fix: "clang-tidy.buildPath" setting

### DIFF
--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -34,7 +34,7 @@ function clangTidyArgs(files: string[], fixErrors: boolean) {
         .get('buildPath') as string;
 
     if (buildPath.length > 0) {
-        args.push(`-p="${buildPath}"`);
+        args.push(`-p=${buildPath}`);
     }
 
     if (fixErrors) {


### PR DESCRIPTION
A quick fix for these issues: 

- https://github.com/notskm/vscode-clang-tidy/issues/21

- https://github.com/notskm/vscode-clang-tidy/issues/14