### PR TITLE
Shorten Github release changelogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,23 +64,53 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Use node.js 12.x
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
 
-      - name: Publish
+      - name: Get project version
+        id: project-version
+        shell: pwsh
+        run: |
+          $project_version = (node -p "require('./package.json').version")
+          echo "::set-output name=version::$project_version"
+
+      - name: Get changelog entry
+        id: changelog_reader
+        uses: mindsers/changelog-reader-action@v1.1.0
+        with:
+          version: ${{ github.ref }}
+          path: ./CHANGELOG.md
+
+      - name: Package
         run: |
           npm ci
           npm run package
-          npm run deploy -p ${{ secrets.VSCE_TOKEN }}
 
-      - name: Github release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: ./clang-tidy-*.*.*.vsix
-          body_path: CHANGELOG.md
+      - name: Publish to VSCode marketplace
+        run: npm run deploy -p ${{ secrets.VSCE_TOKEN }}
+
+      - name: Create Github release
+        id: create_github_release
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.changelog_reader.outputs.log_entry }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_github_release.outputs.upload_url }}
+          asset_path: ./clang-tidy-${{ steps.project-version.outputs.version }}.vsix
+          asset_name: clang-tidy-${{ steps.project-version.outputs.version }}.vsix
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Before, we were attaching the entire changelog file to each Github
release. This commit only attaches the changelog for the latest release.