### PR TITLE
Fix #29: Errors from included file shown as part of parsed file

### DIFF
--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -234,7 +234,7 @@ export function collectDiagnostics(
         const diagnosticMessage = diag.DiagnosticMessage;
 
         if (document.fileName !== diagnosticMessage.FilePath) {
-            return;
+            return; // The message isn't related to current file
         }
 
         if (diagnosticMessage.Replacements.length > 0) {

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -233,6 +233,10 @@ export function collectDiagnostics(
     tidyResults.Diagnostics.forEach((diag) => {
         const diagnosticMessage = diag.DiagnosticMessage;
 
+        if (document.fileName !== diagnosticMessage.FilePath) {
+            return;
+        }
+
         if (diagnosticMessage.Replacements.length > 0) {
             diagnosticMessage.Replacements.forEach((replacement) => {
                 const beginPos = document.positionAt(replacement.Offset);


### PR DESCRIPTION
Small fix to skip lint messages for files that aren't currently linted document.