### PR TITLE
Fix: Diagnostics sometimes aren't being reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+-   Diagnostics sometimes aren't being reported even though clang-tidy finds problems.
+
 ## [0.5.0] - 2020-05-21
 
 ### Added

--- a/src/tidy.ts
+++ b/src/tidy.ts
@@ -172,14 +172,13 @@ interface ClangTidyYaml {
 }
 
 function tidyOutputAsObject(clangTidyOutput: string) {
-    const regex = /(^\-\-\-(.*\n)*\.\.\.$)/gm;
-    const match = regex.exec(clangTidyOutput);
-
-    if (!match) {
+    const yamlIndex = clangTidyOutput.search(/^---$/m);
+    if (yamlIndex < 0) {
         return { MainSourceFile: "", Diagnostics: [] };
     }
+    const rawYaml = clangTidyOutput.substr(yamlIndex);
 
-    const tidyResults = jsYaml.safeLoad(match[0]) as ClangTidyYaml;
+    const tidyResults = jsYaml.safeLoad(rawYaml) as ClangTidyYaml;
 
     let structuredResults: ClangTidyResults = {
         MainSourceFile: tidyResults.MainSourceFile,


### PR DESCRIPTION
For some reason, the regex matching clang-tidy's yaml output sometimes
failed. I couldn't make a regex that worked consistently.

The solution is to use string.search with a very simple regex that
matches a "---" line exactly. This gives us the index where the yaml
part of clang-tidy's output begins. From there, string.substring gives
us the full yaml text.