### PR TITLE
Add quickfix support to vscode-lang-tidy

### DIFF
--- a/src/clang-tidy-yaml.ts
+++ b/src/clang-tidy-yaml.ts
@@ -1,0 +1,47 @@
+import {DiagnosticSeverity} from "vscode"
+
+export interface ClangTidyResults {
+    MainSourceFile: string;
+    Diagnostics: ClangTidyDiagnostic[];
+}
+
+export interface ClangTidyDiagnostic {
+    DiagnosticName: string;
+    DiagnosticMessage: {
+        Message: string;
+        FilePath: string;
+        FileOffset: number;
+        Replacements: ClangTidyReplacement[];
+        Severity: DiagnosticSeverity | DiagnosticSeverity.Warning;
+    };
+}
+
+export interface ClangTidyReplacement {
+    FilePath: string;
+    Offset: number;
+    Length: number;
+    ReplacementText: string;
+}
+
+export interface ClangTidyYaml {
+    MainSourceFile: string;
+    Diagnostics: [
+        {
+            DiagnosticName: string;
+
+            // Old style diagnostic info. For older versions of clang-tidy
+            Message?: string;
+            FilePath?: string;
+            FileOffset?: number;
+            Replacements?: ClangTidyReplacement[];
+
+            // Newer style diagnostic info. For newer versions of clang-tidy
+            DiagnosticMessage?: {
+                Message: string;
+                FilePath: string;
+                FileOffset: number;
+                Replacements: ClangTidyReplacement[];
+            };
+        }
+    ];
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,20 @@
+import { type } from "os";
 import * as vscode from "vscode";
-import { commands, workspace } from "vscode";
+import { CodeActionKind, commands, TextEdit, workspace } from "vscode";
+import { ClangTidyReplacement } from "./clang-tidy-yaml";
 
 import { lintTextDocument, lintActiveTextDocument } from "./lint";
 
-import { killClangTidy } from "./tidy";
+import { killClangTidy, } from "./tidy";
 
 export function activate(context: vscode.ExtensionContext) {
     let subscriptions = context.subscriptions;
+
+    context.subscriptions.push(
+        vscode.languages.registerCodeActionsProvider('cpp', new ClangTidyInfo(), {
+            providedCodeActionKinds: ClangTidyInfo.providedCodeActionKinds
+        })
+    );
 
     let diagnosticCollection = vscode.languages.createDiagnosticCollection();
     subscriptions.push(diagnosticCollection);
@@ -87,4 +95,45 @@ export function activate(context: vscode.ExtensionContext) {
     workspace.textDocuments.forEach((doc) => lintAndSetDiagnostics(doc));
 }
 
-export function deactivate() {}
+/**
+ * Provides code actions corresponding to diagnostic problems.
+ */
+export class ClangTidyInfo implements vscode.CodeActionProvider {
+
+    public static readonly providedCodeActionKinds = [
+        vscode.CodeActionKind.QuickFix
+    ];
+
+    provideCodeActions(document: vscode.TextDocument, range: vscode.Range | vscode.Selection, context: vscode.CodeActionContext, token: vscode.CancellationToken): vscode.CodeAction[] {
+        // for each diagnostic entry that has the matching `code`, create a code action command
+        return context.diagnostics
+            .reduce((acc, diagnostic) => {
+                const action = this.createCommandCodeAction(document, diagnostic);
+                if (!!action) {
+                    acc.push(action);
+                }
+                return acc;
+            }, [] as vscode.CodeAction[]);
+    }
+
+    private createCommandCodeAction(document: vscode.TextDocument, diagnostic: vscode.Diagnostic): vscode.CodeAction | null {
+        if (diagnostic.source !== "clang-tidy" || !diagnostic.code || typeof (diagnostic.code) !== "string") {
+            return null;
+        }
+        const [text, offset, len] = JSON.parse(diagnostic.code) as [string, number, number];
+        const changes = new vscode.WorkspaceEdit();
+        changes.replace(document.uri,
+            new vscode.Range(
+                document.positionAt(offset),
+                document.positionAt(offset + len)),
+            text);
+        return {
+            title: `[Clang-Tidy] Change to ${text}`,
+            diagnostics: [diagnostic],
+            kind: CodeActionKind.QuickFix,
+            edit: changes
+        };
+    }
+}
+
+export function deactivate() { }

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -25,12 +25,10 @@ function isBlacklisted(file: vscode.TextDocument) {
 
     const relativeFilename = vscode.workspace.asRelativePath(file.fileName);
 
-    for (let i = 0; i < blacklist.length; i++) {
-        const regex = new RegExp(blacklist[i]);
-        if (regex.test(relativeFilename)) {
-            return true;
-        }
-    }
+    return blacklist.some(entry => {
+        const regex = new RegExp(entry);
+        return regex.test(relativeFilename);
+    });
 }
 
 export async function lintTextDocument(


### PR DESCRIPTION
This patch adds quickfix support so that the many
clang-tidy checks with fixes can automatically be applied
to the code. This is related to issue #42 .

Unfortunatelly, the patch also contains some refactoring,
which helped me to find my way around the code.
If there is a general interest in merging this patch, I can, of course, remove these
refactorings.