### PR TITLE
Handle compilation database with relative paths

### DIFF
--- a/src/clang-tidy-yaml.ts
+++ b/src/clang-tidy-yaml.ts
@@ -14,6 +14,7 @@ export interface ClangTidyDiagnostic {
         Replacements: ClangTidyReplacement[];
         Severity: DiagnosticSeverity | DiagnosticSeverity.Warning;
     };
+    BuildDirectory?: string;
 }
 
 export interface ClangTidyReplacement {
@@ -42,6 +43,8 @@ export interface ClangTidyYaml {
                 FileOffset: number;
                 Replacements: ClangTidyReplacement[];
             };
+
+            BuildDirectory?: string;
         }
     ];
 }


### PR DESCRIPTION
Addresses Issue #38.  Tested with Clang 11.0.0 (using Bear 2.4.3 for database generation).